### PR TITLE
refactor: centralize hover effects

### DIFF
--- a/galeria.html
+++ b/galeria.html
@@ -338,6 +338,7 @@
         </div>
     </footer>
 
-    <script src="js/gallery.js"></script>
+    <script src="js/main.js"></script>
+    <script src="js/galeria.js"></script>
 </body>
 </html>

--- a/js/galeria.js
+++ b/js/galeria.js
@@ -63,23 +63,23 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // Efecto hover mejorado para elementos de galería
-    galleryItems.forEach(item => {
-        const overlay = item.querySelector('.gallery-overlay');
-        
-        item.addEventListener('mouseenter', function() {
-            this.style.transform = 'translateY(-5px) scale(1.02)';
+    addHoverEffect(
+        galleryItems,
+        item => {
+            const overlay = item.querySelector('.gallery-overlay');
+            item.style.transform = 'translateY(-5px) scale(1.02)';
             if (overlay) {
                 overlay.style.opacity = '1';
             }
-        });
-        
-        item.addEventListener('mouseleave', function() {
-            this.style.transform = 'translateY(0) scale(1)';
+        },
+        item => {
+            const overlay = item.querySelector('.gallery-overlay');
+            item.style.transform = 'translateY(0) scale(1)';
             if (overlay) {
                 overlay.style.opacity = '0';
             }
-        });
-    });
+        }
+    );
 
     // Contador de obras por categoría
     updateWorkCount();

--- a/js/main.js
+++ b/js/main.js
@@ -66,18 +66,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Efecto hover mejorado para elementos interactivos
     const interactiveElements = document.querySelectorAll('.btn, .card, .gallery-item');
-    interactiveElements.forEach(element => {
-        element.addEventListener('mouseenter', function() {
-            this.style.transform = 'translateY(-2px)';
-        });
-        
-        element.addEventListener('mouseleave', function() {
-            this.style.transform = 'translateY(0)';
-        });
-    });
+    addHoverEffect(
+        interactiveElements,
+        el => {
+            el.style.transform = 'translateY(-2px)';
+        },
+        el => {
+            el.style.transform = 'translateY(0)';
+        }
+    );
 });
 
 // ===== UTILIDADES =====
+
+// Agrega efectos hover personalizados a una lista de elementos
+function addHoverEffect(elements, onEnter, onLeave) {
+    elements.forEach(element => {
+        element.addEventListener('mouseenter', () => onEnter(element));
+        element.addEventListener('mouseleave', () => onLeave(element));
+    });
+}
 
 // Función para mostrar notificaciones
 function showNotification(message, type = 'info') {


### PR DESCRIPTION
## Summary
- centralize hover effect logic with a reusable helper
- use shared helper for gallery items and fix script reference
- include main script on gallery page to expose utilities

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960f280384833287cfff392b728269